### PR TITLE
.gitignoreに/specを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ node_modules
 !/app/assets/builds/.keep
 
 /node_modules
-
+/spec
 /public/packs
 /public/packs-test
 /node_modules


### PR DESCRIPTION
テストを実行する既存ファイルが存在するため、specフォルダを削除